### PR TITLE
Fix page title displaying as 'untitled' in Google search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@
 # https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/#installing-the-theme
 
 # theme                  : "minimal-mistakes-jekyll"
-# remote_theme           : "mmistakes/minimal-mistakes"
+remote_theme           : "mmistakes/minimal-mistakes"
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings

--- a/index.md
+++ b/index.md
@@ -1,4 +1,5 @@
 ---
+layout: home
 title: Jack Landry
 description: Website for Jack Landry, Lead Researcher, Jain Family Institute
 author_profile: true


### PR DESCRIPTION
- Uncommented remote_theme in _config.yml to enable Minimal Mistakes theme
- Added layout to index.md front matter for proper page rendering

The remote_theme was previously commented out, preventing GitHub Pages from properly building the site with the theme templates, which likely resulted in missing or incorrect title tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)